### PR TITLE
Adding test to ensure Redis multiplexer is only created once per Redi…

### DIFF
--- a/IdentityServer4.Contrib.RedisStore.Tests/UnitTesting/RedisOptionsTests.cs
+++ b/IdentityServer4.Contrib.RedisStore.Tests/UnitTesting/RedisOptionsTests.cs
@@ -1,0 +1,24 @@
+﻿using Xunit;
+
+namespace IdentityServer4.Contrib.RedisStore.Tests.UnitTesting
+{
+    public class RedisOptionsTests
+    {
+        [Fact]
+        public void RedisOptions_Multiplexer_Is_Only_Created_Once()
+        {
+            string connectionString = ConfigurationUtils.GetConfiguration()["Redis:ConnectionString"];
+            var options = new TestRedisOptions {RedisConnectionString = connectionString};
+
+            var multiplexer = options.Multiplexer;
+            var multiplexer2 = options.Multiplexer;
+
+            Assert.Same(multiplexer, multiplexer2);
+        }
+
+	    private class TestRedisOptions : RedisOptions
+	    {
+
+	    }
+    }
+}

--- a/IdentityServer4.Contrib.RedisStore/Extensions/RedisOptions.cs
+++ b/IdentityServer4.Contrib.RedisStore/Extensions/RedisOptions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using StackExchange.Redis;
 
+[assembly: InternalsVisibleTo("IdentityServer4.Contrib.RedisStore.Tests")]
 namespace IdentityServer4.Contrib.RedisStore
 {
     /// <summary>


### PR DESCRIPTION
@AliBazzi , thank you for passing along the issue with the Lazy method and for fixing it! I added a test to ensure that calling RedisOptions.Multiplexer isn't creating a new Multiplexer each time. I'm using `System.Runtime.CompilerServices` to expose the internal methods to the test project and XUnit's `Assert.Same` to check reference equality.