### PR TITLE
Add option to re-throw exception

### DIFF
--- a/IdentityServer4.Contrib.RedisStore/Stores/PersistedGrantStore.cs
+++ b/IdentityServer4.Contrib.RedisStore/Stores/PersistedGrantStore.cs
@@ -82,7 +82,8 @@ namespace IdentityServer4.Contrib.RedisStore.Stores
             }
             catch (Exception ex)
             {
-                logger.LogWarning($"exception storing persisted grant to Redis database for subject {grant.SubjectId}, clientId {grant.ClientId}, grantType {grant.Type} : {ex.Message}");
+                logger.LogError($"exception storing persisted grant to Redis database for subject {grant.SubjectId}, clientId {grant.ClientId}, grantType {grant.Type} : {ex.Message}");
+                throw ex;
             }
         }
 
@@ -135,7 +136,8 @@ namespace IdentityServer4.Contrib.RedisStore.Stores
             }
             catch (Exception ex)
             {
-                logger.LogInformation($"exception removing {key} persisted grant from database: {ex.Message}");
+                logger.LogError($"exception removing {key} persisted grant from database: {ex.Message}");
+                throw ex;
             }
 
         }
@@ -155,7 +157,8 @@ namespace IdentityServer4.Contrib.RedisStore.Stores
             }
             catch (Exception ex)
             {
-                logger.LogInformation($"removing persisted grants from database for subject {subjectId}, clientId {clientId}: {ex.Message}");
+                logger.LogError($"exception removing persisted grants from database for subject {subjectId}, clientId {clientId}: {ex.Message}");
+                throw ex;
             }
         }
 
@@ -175,7 +178,8 @@ namespace IdentityServer4.Contrib.RedisStore.Stores
             }
             catch (Exception ex)
             {
-                logger.LogInformation($"exception removing persisted grants from database for subject {subjectId}, clientId {clientId}, grantType {type}: {ex.Message}");
+                logger.LogError($"exception removing persisted grants from database for subject {subjectId}, clientId {clientId}, grantType {type}: {ex.Message}");
+                throw ex;
             }
         }
 


### PR DESCRIPTION
Currently exceptions are getting swallowed, I'd like to be able to let them bubble up. Without this, a refresh token could get issued to a client that can never actually be used

Set the option to false by default so should be backwards compatible

Also changed log levels to error inside catch statements.

Updated from netstandard1.6 to 2.0