### PR TITLE
Replace IPersistedGrantStore

### DIFF
--- a/IdentityServer4.Contrib.RedisStore/Extensions/IdentityServerRedisBuilderExtensions.cs
+++ b/IdentityServer4.Contrib.RedisStore/Extensions/IdentityServerRedisBuilderExtensions.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.AddSingleton(options);
 
             builder.Services.AddScoped<RedisMultiplexer<RedisOperationalStoreOptions>>();
+            builder.Services.RemoveAll<IPersistedGrantStore>();
             builder.Services.AddTransient<IPersistedGrantStore, PersistedGrantStore>();
             return builder;
         }


### PR DESCRIPTION
This change will replace the service IPersistedGrantStore instead of registering a second version of it. (#14)