### PR TITLE
updated stackexchange redis package to version 2.1.0

### DIFF
--- a/IdentityServer4.Contrib.RedisStore/IdentityServer4.Contrib.RedisStore.csproj
+++ b/IdentityServer4.Contrib.RedisStore/IdentityServer4.Contrib.RedisStore.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="IdentityServer4" Version="3.0.*" />
     <PackageReference Include="IdentityServer4.Storage" Version="3.0.*" />
-    <PackageReference Include="StackExchange.Redis" Version="2.0.519" />
+    <PackageReference Include="StackExchange.Redis" Version="2.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I am experiencing a number of redis related issues which are tracked in this issue: https://github.com/StackExchange/StackExchange.Redis/issues/1120. The latest stable version of stackexchange was released today which addresses some of those connection related issues
